### PR TITLE
BUG FIX: Uploads of entry list should always have runner status Ok

### DIFF
--- a/app_rest/plugins/Results/src/Model/Entity/Runner.php
+++ b/app_rest/plugins/Results/src/Model/Entity/Runner.php
@@ -131,7 +131,7 @@ class Runner extends AppEntity implements ParticipantInterface
                 //$res->start_time = '';
                 //$res->finish_time = '';
                 $res->upload_type = UploadTypes::ENTRY_LIST; // could use also UploadTypes::START_LIST
-                $res->status_code = StatusCode::DNS; // could also use StatusCode::OK
+                $res->status_code = StatusCode::OK;
                 $res->time_seconds = 0;
                 $res->position = 0;
                 $res->is_nc = false;

--- a/app_rest/plugins/Results/tests/TestCase/Controller/ResultsControllerTest.php
+++ b/app_rest/plugins/Results/tests/TestCase/Controller/ResultsControllerTest.php
@@ -8,6 +8,8 @@ use App\Controller\ApiController;
 use App\Test\TestCase\Controller\ApiCommonErrorsTest;
 use Cake\Datasource\ResultSetInterface;
 use Cake\I18n\FrozenTime;
+use Results\Lib\Consts\StatusCode;
+use Results\Lib\Consts\UploadTypes;
 use Results\Model\Entity\ClassEntity;
 use Results\Model\Entity\Club;
 use Results\Model\Entity\Control;
@@ -226,8 +228,8 @@ class ResultsControllerTest extends ApiCommonErrorsTest
                     'stage' => [
                         '_c' => 'Result',
                         'result_type_id' => '',
-                        'upload_type' => 'entry_list',
-                        'status_code' => '1',
+                        'upload_type' => UploadTypes::ENTRY_LIST,
+                        'status_code' => StatusCode::OK,
                         'time_seconds' => 0,
                         'position' => 0,
                         'is_nc' => false,

--- a/app_rest/plugins/Results/tests/TestCase/Model/Table/TeamsTableTest.php
+++ b/app_rest/plugins/Results/tests/TestCase/Model/Table/TeamsTableTest.php
@@ -5,6 +5,8 @@ declare(strict_types = 1);
 namespace Results\Test\TestCase\Model\Table;
 
 use Cake\TestSuite\TestCase;
+use Results\Lib\Consts\StatusCode;
+use Results\Lib\Consts\UploadTypes;
 use Results\Model\Entity\Event;
 use Results\Model\Entity\Runner;
 use Results\Model\Entity\Stage;
@@ -74,8 +76,8 @@ class TeamsTableTest extends TestCase
             'position' => 0,
             'is_nc' => false,
             'time_behind' => 0,
-            'upload_type' => 'entry_list',
-            'status_code' => '1',
+            'upload_type' => UploadTypes::ENTRY_LIST,
+            'status_code' => StatusCode::OK,
             'splits' => [],
         ], json_decode(json_encode($runnerB->_getStage()), true));
     }


### PR DESCRIPTION
The runner status DNS means that after all the starts have taken place, the runner did not go to the start. This is not the case of an entry list upload. In an entry list, the upload reassembles that of a start list. Runners are `ok` until any other update on their status arrives.